### PR TITLE
Correcting conditionals looping

### DIFF
--- a/lib/ansible/modules/network/vyos/vyos_command.py
+++ b/lib/ansible/modules/network/vyos/vyos_command.py
@@ -212,10 +212,10 @@ def main():
                     break
                 conditionals.remove(item)
 
-            if not conditionals:
-                break
+        if not conditionals:
+            break
 
-            time.sleep(interval)
+        time.sleep(interval)
 
     if conditionals:
         failed_conditions = [item.raw for item in conditionals]


### PR DESCRIPTION
##### SUMMARY
Empty conditionals would not break out of the loop, causing every command to be run for the same number of times as retries is defined (10 by default)

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
- vyos_command

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.1
  config file = /root/.ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.5 (default, Jul 13 2018, 13:06:57) [GCC 4.8.5 20150623 (Red Hat 4.8.5-28)]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Assume the following playbook
```
  tasks:
  - name: Get version
    vyos_command:
      commands: "history"
```

The following can be seen in stdout_lines:
```
    "stdout_lines": [
        [
            "1  set terminal length 0",
            "    2  set terminal width 512",
            "    3  set terminal length 10000",
            "    4  show version",
            "    5  show host name",
            "    6  history",
            "    7  history",
            "    8  history",
            "    9  history",
            "   10  history",
            "   11  history",
            "   12  history",
            "   13  history",
            "   14  history",
            "   15  history"
```